### PR TITLE
Fix install error due to missing Hashicorp password package

### DIFF
--- a/kek/asker.go
+++ b/kek/asker.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"encoding/hex"
 
-	"github.com/hashicorp/vault/helper/password"
+	"github.com/hashicorp/vault/sdk/helper/password"
 )
 
 type Asker struct {


### PR DESCRIPTION
Update path to Hashicorp vault "password" library in order to resolve the install error:
"package github.com/hashicorp/vault/helper/password: cannot find package "github.com/hashicorp/vault/helper/password" in any of:"